### PR TITLE
Update main.go

### DIFF
--- a/cmd/boring/main.go
+++ b/cmd/boring/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"slices"
-	"strings"
 	"syscall"
 
 	"github.com/alebeck/boring/internal/config"
@@ -16,7 +16,6 @@ import (
 	"github.com/alebeck/boring/internal/log"
 	"github.com/alebeck/boring/internal/table"
 	"github.com/alebeck/boring/internal/tunnel"
-
 	"github.com/creack/pty"
 	"golang.org/x/term"
 )
@@ -215,65 +214,6 @@ func listTunnels() {
 	tbl.Print()
 }
 
-func connectTunnel(name string) {
-	conf, err := prepare()
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
-	t, ok := conf.TunnelsMap[name]
-	if !ok {
-		log.Fatalf("Tunnel '%s' not found in configuration (%s).", name, config.FileName)
-	}
-
-	// Extract hostname and port from the tunnel configuration
-	hostname := t.Host
-	port := "22" // Default SSH port
-	if strings.Contains(t.RemoteAddress, ":") {
-		port = strings.Split(t.RemoteAddress, ":")[1]
-	}
-
-	// Check if User is available in the tunnel configuration
-	user := "root" // Default user if not specified
-	if t.User != "" {
-		user = t.User
-	}
-
-	// Construct the SSH command
-	sshArgs := []string{fmt.Sprintf("%s@%s", user, hostname), "-p", port}
-	cmd := exec.Command("ssh", sshArgs...)
-
-	// Start the command with a pty
-	ptmx, err := pty.Start(cmd)
-	if err != nil {
-		log.Fatalf("Failed to start ssh command: %v", err)
-	}
-	defer func() { _ = ptmx.Close() }() // Best effort.
-
-	// Handle pty size
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGWINCH)
-	go func() {
-		for range ch {
-			if err := pty.InheritSize(os.Stdin, ptmx); err != nil {
-				log.Errorf("Error resizing pty: %v", err)
-			}
-		}
-	}()
-	ch <- syscall.SIGWINCH // Initial resize.
-
-	// Set stdin in raw mode
-	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
-	if err != nil {
-		log.Fatalf("Failed to set raw terminal: %v", err)
-	}
-	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort.
-
-	// Copy input/output
-	go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
-	_, _ = io.Copy(os.Stdout, ptmx)
-}
-
 func transmitCmd(cmd daemon.Cmd, resp any) error {
 	conn, err := daemon.Connect()
 	if err != nil {
@@ -297,5 +237,119 @@ func printUsage() {
 	fmt.Println("  boring list,l                        List tunnels")
 	fmt.Println("  boring open,o <name1> [<name2> ...]  Open specified tunnel(s)")
 	fmt.Println("  boring close,c <name1> [<name2> ...] Close specified tunnel(s)")
-	fmt.Println("  boring connect <name>                Connect to specified tunnel via SSH")
+	fmt.Println("  boring connect <name> [-t]           Connect to specified tunnel via SSH.  -t starts/resumes tmux.")
+}
+
+func connectTunnel(name string) {
+	conf, err := prepare()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	t, ok := conf.TunnelsMap[name]
+	if !ok {
+		log.Fatalf("Tunnel '%s' not found in configuration (%s).", name, config.FileName)
+	}
+
+	// Check if the -t flag is provided (use tmux if -t is passed)
+	useTmux := false
+	if len(os.Args) > 3 && os.Args[3] == "-t" {
+		useTmux = true
+	}
+
+	// Check the status of the tunnel to see if it's already running
+	var resp daemon.Resp
+	cmd := daemon.Cmd{Kind: daemon.List}
+	if err = transmitCmd(cmd, &resp); err != nil {
+		log.Fatalf("Could not check tunnel status: %v", err)
+	}
+
+	tunnelStatus, found := resp.Tunnels[name]
+	if !found || tunnelStatus.Status != tunnel.Open {
+		// If the tunnel is not open, attempt to open it
+		log.Infof("Opening tunnel %s...", name)
+		cmd := daemon.Cmd{Kind: daemon.Open, Tunnel: *t}
+		if err := transmitCmd(cmd, &resp); err != nil {
+			log.Fatalf("Could not transmit 'open' command: %v", err)
+		}
+
+		if !resp.Success {
+			log.Fatalf("Tunnel %v could not be opened: %v", name, resp.Error)
+		}
+	} else {
+		log.Infof("Tunnel '%s' is already running.", name)
+	}
+
+	// Extract hostname and port from the local tunnel address
+	localAddress := t.LocalAddress.String()
+	host, port, err := net.SplitHostPort(localAddress)
+	if err != nil {
+		log.Fatalf("Invalid local address '%s': %v", localAddress, err)
+	}
+
+	// Use localhost if host is empty or '*'
+	if host == "" || host == "*" {
+		host = "localhost"
+	}
+
+	// SSH control path for multiplexing
+	controlPath := fmt.Sprintf("/tmp/ssh_mux_%s@%s:%s", os.Getenv("USER"), host, port)
+
+	// SSH arguments
+	var sshArgs []string
+	if useTmux {
+		// If -r is passed, use tmux to reconnect or start a new tmux session
+		sshArgs = []string{
+			"-t",       // Force pseudo-terminal allocation
+			"-p", port, // Specify port
+			"-o", fmt.Sprintf("ControlPath=%s", controlPath),
+			"-o", "ControlMaster=auto",
+			"-o", "ControlPersist=600", // Keep session open for 10 minutes
+			host,
+			"tmux new-session -A -s boring-session", // Automatically attach or create a tmux session
+		}
+	} else {
+		// Normal SSH connection without tmux
+		sshArgs = []string{
+			"-t",       // Force pseudo-terminal allocation
+			"-p", port, // Specify port
+			"-o", fmt.Sprintf("ControlPath=%s", controlPath),
+			"-o", "ControlMaster=auto",
+			"-o", "ControlPersist=600", // Keep session open for 10 minutes
+			host,
+		}
+	}
+
+	// Create the SSH command
+	cmdSSH := exec.Command("ssh", sshArgs...)
+
+	// Start the SSH command with a PTY
+	ptmx, err := pty.Start(cmdSSH)
+	if err != nil {
+		log.Fatalf("Failed to start ssh command: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }() // Best effort cleanup
+
+	// Handle PTY size changes (resize handling)
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		for range ch {
+			if err := pty.InheritSize(os.Stdin, ptmx); err != nil {
+				log.Errorf("Error resizing pty: %v", err)
+			}
+		}
+	}()
+	ch <- syscall.SIGWINCH // Initial resize
+
+	// Set stdin in raw mode (for proper terminal handling)
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		log.Fatalf("Failed to set raw terminal: %v", err)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort cleanup
+
+	// Copy input/output between the user's terminal and the SSH session
+	go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
+	_, _ = io.Copy(os.Stdout, ptmx)
 }

--- a/cmd/boring/main.go
+++ b/cmd/boring/main.go
@@ -34,15 +34,25 @@ func main() {
 
 	switch os.Args[1] {
 	case "open", "o":
-		if len(os.Args) < 3 {
-			log.Fatalf("'open' requires at least one 'name' argument.")
+		if len(os.Args) == 3 && os.Args[2] == "-a" {
+			// Open all tunnels
+			openAllTunnels()
+		} else if len(os.Args) < 3 {
+			log.Fatalf("'open' requires at least one 'name' argument or '-a' to open all tunnels.")
+		} else {
+			// Open specific tunnels
+			controlTunnels(os.Args[2:], daemon.Open)
 		}
-		controlTunnels(os.Args[2:], daemon.Open)
 	case "close", "c":
-		if len(os.Args) < 3 {
-			log.Fatalf("'close' requires at least one 'name' argument.")
+		if len(os.Args) == 3 && os.Args[2] == "-a" {
+			// Close all tunnels
+			closeAllTunnels()
+		} else if len(os.Args) < 3 {
+			log.Fatalf("'close' requires at least one 'name' argument or '-a' to close all tunnels.")
+		} else {
+			// Close specific tunnels
+			controlTunnels(os.Args[2:], daemon.Close)
 		}
-		controlTunnels(os.Args[2:], daemon.Close)
 	case "list", "l":
 		listTunnels()
 	case "ssh":
@@ -55,6 +65,48 @@ func main() {
 		printUsage()
 		os.Exit(1)
 	}
+}
+
+func closeAllTunnels() {
+	conf, err := prepare()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	// Extract all tunnel names from the configuration
+	var tunnelNames []string
+	for _, tunnel := range conf.Tunnels {
+		tunnelNames = append(tunnelNames, tunnel.Name)
+	}
+
+	if len(tunnelNames) == 0 {
+		log.Infof("No tunnels found in the configuration.")
+		return
+	}
+
+	// Close all tunnels
+	controlTunnels(tunnelNames, daemon.Close)
+}
+
+func openAllTunnels() {
+	conf, err := prepare()
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+
+	// Extract all tunnel names from the configuration
+	var tunnelNames []string
+	for _, tunnel := range conf.Tunnels {
+		tunnelNames = append(tunnelNames, tunnel.Name)
+	}
+
+	if len(tunnelNames) == 0 {
+		log.Infof("No tunnels found in the configuration.")
+		return
+	}
+
+	// Open all tunnels
+	controlTunnels(tunnelNames, daemon.Open)
 }
 
 // prepare loads the configuration and ensures the daemon is running

--- a/cmd/boring/main.go
+++ b/cmd/boring/main.go
@@ -45,11 +45,11 @@ func main() {
 		controlTunnels(os.Args[2:], daemon.Close)
 	case "list", "l":
 		listTunnels()
-	case "connect":
+	case "ssh":
 		if len(os.Args) < 3 {
-			log.Fatalf("'connect' requires a 'name' argument.")
+			log.Fatalf("'ssh' requires a 'name' argument.")
 		}
-		connectTunnel(os.Args[2])
+		sshToTunnel(os.Args[2])
 	default:
 		fmt.Println("Unknown command:", os.Args[1])
 		printUsage()
@@ -237,10 +237,10 @@ func printUsage() {
 	fmt.Println("  boring list,l                        List tunnels")
 	fmt.Println("  boring open,o <name1> [<name2> ...]  Open specified tunnel(s)")
 	fmt.Println("  boring close,c <name1> [<name2> ...] Close specified tunnel(s)")
-	fmt.Println("  boring connect <name> [-t]           Connect to specified tunnel via SSH.  -t starts/resumes tmux.")
+	fmt.Println("  boring ssh <name> [-t]               SSH to specified tunnel.  -t starts/resumes tmux.")
 }
 
-func connectTunnel(name string) {
+func sshToTunnel(name string) {
 	conf, err := prepare()
 	if err != nil {
 		log.Fatalf(err.Error())

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.23.0
 
 require (
 	github.com/BurntSushi/toml v1.4.0
+	github.com/creack/pty v1.1.23
 	github.com/kevinburke/ssh_config v1.2.0
 	golang.org/x/crypto v0.27.0
+	golang.org/x/term v0.24.0
 )
 
 require golang.org/x/sys v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/creack/pty v1.1.23 h1:4M6+isWdcStXEf15G/RbrMPOQj1dZ7HPZCGwE4kOeP0=
+github.com/creack/pty v1.1.23/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=


### PR DESCRIPTION
1. Add new "connect" command to directly SSH into configured tunnels
   - Implement `connectTunnel` function to handle SSH connections
   - Update main() to include "connect" in the command switch
   - Modify printUsage() to include information about the new command

2. Fix Tunnel struct field access in connectTunnel function
   - Replace t.RemotePort with port extraction from t.RemoteAddress
   - Add fallback to default "root" user if t.User is not specified

3. Update import statements
   - Add "strings" package for string manipulation
   - Remove "strconv" package as it's no longer needed

4. Improve error handling and user feedback
   - Provide more descriptive error messages for configuration issues
   - Use log.Fatalf for critical errors to exit the program

5. Enhance code comments for better maintainability

These changes allow users to easily connect to their configured tunnels using the "boring connect <tunnel_name>" command, improving the overall functionality and user experience of the boring CLI tool.