### PR TITLE
Add config support for XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ Usage:
 ```
 
 ## Configuration
-By default, `boring` reads its configuration from `~/.boring.toml`. The configuration is a simple TOML file describing your tunnels:
+
+The config file can be created in the locations below in order of precedence:
+1. The `BORING_CONFIG` environmental variable can be used to set a custom path
+2. `$XDG_CONFIG_HOME/boring/boring.toml`
+3. `~/.boring.toml`
+
+The configuration is a simple TOML file describing your tunnels:
 
 ```toml
 # simple tunnel

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	golang.org/x/crypto v0.27.0
 )
 
-require golang.org/x/sys v0.25.0 // indirect
+require (
+	github.com/adrg/xdg v0.5.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=
+github.com/adrg/xdg v0.5.0/go.mod h1:dDdY4M4DF9Rjy4kHPeNL+ilVF+p2lK8IdM9/rTSGcI4=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=


### PR DESCRIPTION
This change supports placing the configuration file in `XDG_CONFIG_HOME/boring/boring.toml` while maintaining compatibility with configs already created and in use at `~/.boring.toml`

