### PR TITLE
Add VPN-aware tunnel auto-open and auto-close

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,19 @@ poll_interval = 10
 stable_for = 30
 cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
 
+# optional group defaults for VPN automation
+[group.work]
+vpn_required = true
+auto_open_when_vpn = true
+auto_close_when_vpn_lost = true
+
 # simple tunnel
 [[tunnels]]
 name = "dev"
 local = "9000"
 remote = "localhost:9000"
 host = "dev-server"  # automatically matches host against SSH config
-vpn_required = true
-auto_open_when_vpn = true
-auto_close_when_vpn_lost = true
+group = "work"
 
 # example of an explicit host (no SSH config)
 [[tunnels]]
@@ -94,6 +98,8 @@ Currently, supported options at tunnel level are:
 | `vpn_required` | If `true`, the tunnel is only eligible for VPN automation while a local interface IP matches one of the configured `vpn.cidrs`. Manual `open` and `close` behavior is unchanged.                    |
 | `auto_open_when_vpn` | If `true`, the daemon automatically opens the tunnel when it is eligible.                                                                                                                        |
 | `auto_close_when_vpn_lost` | If `true`, the daemon automatically closes the tunnel when it is no longer eligible because VPN detection fails.                                                                      |
+
+The same VPN automation flags can also be set as group defaults using `[group.<name>]`. For tunnels without a group, use `[group.default]`. Tunnel-level `true` values and group-level `true` values are combined.
 
 Top-level VPN options:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Get it: `brew install boring`
 * Works with SSH config and `ssh-agent`
 * Supports Unix sockets
 * Automatic re-connection and keep-alives
+* VPN-aware auto-open and auto-close for selected tunnels
 * Human-friendly TOML configuration
 * Cross platform support
 * Smart shell completions
@@ -49,12 +50,21 @@ Usage:
 By default, `boring` reads its configuration from `~/.boring.toml` on macOS and Windows, and from `$XDG_CONFIG_HOME/boring/.boring.toml` on Linux. If `$XDG_CONFIG_HOME` is not set, it defaults to `~/.config`. The location of the config file can be overriden by setting `$BORING_CONFIG`. The config is a simple TOML file describing your tunnels:
 
 ```toml
+# optional CIDR-based VPN detection for tunnel automation
+[vpn]
+poll_interval = 10
+stable_for = 30
+cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
+
 # simple tunnel
 [[tunnels]]
 name = "dev"
 local = "9000"
 remote = "localhost:9000"
 host = "dev-server"  # automatically matches host against SSH config
+vpn_required = true
+auto_open_when_vpn = true
+auto_close_when_vpn_lost = true
 
 # example of an explicit host (no SSH config)
 [[tunnels]]
@@ -81,6 +91,19 @@ Currently, supported options at tunnel level are:
 | `identity`    | SSH identity file. If not set, tries to read it from SSH config and `ssh-agent`, defaulting to standard identity files.                                                            |
 | `port`        | SSH port. If not set, tries to read it from SSH config, defaulting to `22`.                                                                                                        |
 | `group`        | Group that the tunnel is assigned to. Groups are only shown in `list` view if at least one tunnel has a group assigned. Can be used for grouped `open`, `close`, and `list`.                         |
+| `vpn_required` | If `true`, the tunnel is only eligible for VPN automation while a local interface IP matches one of the configured `vpn.cidrs`. Manual `open` and `close` behavior is unchanged.                    |
+| `auto_open_when_vpn` | If `true`, the daemon automatically opens the tunnel when it is eligible.                                                                                                                        |
+| `auto_close_when_vpn_lost` | If `true`, the daemon automatically closes the tunnel when it is no longer eligible because VPN detection fails.                                                                      |
+
+Top-level VPN options:
+
+| **Option** | **Description** |
+|------------|-----------------|
+| `vpn.poll_interval` | Seconds between daemon VPN checks. Default: `10`. |
+| `vpn.stable_for` | Seconds an observed VPN state must stay unchanged before opening or closing tunnels. Default: `30`. |
+| `vpn.cidrs` | CIDR ranges that identify the VPN. The daemon considers the VPN connected when any active, non-loopback interface IP is inside any range. |
+
+VPN detection is CIDR-based only; it does not run custom commands, inspect interface names, probe DNS, or parse route tables.
 
 Options that can be provided at global and tunnel level (tunnel level takes precedence):
 

--- a/cmd/boring/config.go
+++ b/cmd/boring/config.go
@@ -14,6 +14,12 @@ const defaultConfig = `# An example tunnel is defined below.
 # For more examples, please visit the project's GitHub page.
 # All lines starting with '#' are comments.
 
+# Optional VPN detection for auto-opening/closing marked tunnels.
+# [vpn]
+# poll_interval = 10  # seconds between checks
+# stable_for = 30     # seconds the VPN state must remain unchanged
+# cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
+
 # [[tunnels]]
 # name = "dev"  # Name for the tunnel
 # local = 9000  # Local address to listen on
@@ -22,6 +28,9 @@ const defaultConfig = `# An example tunnel is defined below.
 # port = 22  # (Optional) Server port, defaults to 22
 # user = "neo"  # (Optional) Username, tries ssh config and defaults to $USER
 # identity = "~/.ssh/id_dev"  # (Optional) Key file, tries ssh config and defaults to default keys
+# vpn_required = true  # (Optional) Only eligible for automation while VPN CIDRs match
+# auto_open_when_vpn = true  # (Optional) Auto-open when eligible
+# auto_close_when_vpn_lost = true  # (Optional) Auto-close when VPN is lost
 
 `
 

--- a/cmd/boring/config.go
+++ b/cmd/boring/config.go
@@ -20,11 +20,18 @@ const defaultConfig = `# An example tunnel is defined below.
 # stable_for = 30     # seconds the VPN state must remain unchanged
 # cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
 
+# Optional group defaults for VPN automation.
+# [group.work]
+# vpn_required = true
+# auto_open_when_vpn = true
+# auto_close_when_vpn_lost = true
+
 # [[tunnels]]
 # name = "dev"  # Name for the tunnel
 # local = 9000  # Local address to listen on
 # remote = "localhost:9000"  # Remote address to forward to
 # host = "dev-server"  # Hostname of the server, tries to match against ssh config
+# group = "work"  # (Optional) Group for batch operations and group defaults
 # port = 22  # (Optional) Server port, defaults to 22
 # user = "neo"  # (Optional) Username, tries ssh config and defaults to $USER
 # identity = "~/.ssh/id_dev"  # (Optional) Key file, tries ssh config and defaults to default keys

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,9 +1,19 @@
+# Optional CIDR-based VPN detection. Tunnels with the VPN flags below can be
+# opened automatically when any active, non-loopback interface IP matches.
+# [vpn]
+# poll_interval = 10
+# stable_for = 30
+# cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
+
 # simple tunnel, uses local (-L) mode by default
 [[tunnels]]
 name = "dev"
 local = "9000"
 remote = "localhost:9000"
 host = "dev-server"       # automatically matches host against SSH config
+# vpn_required = true
+# auto_open_when_vpn = true
+# auto_close_when_vpn_lost = true
 
 # simple remote (-R) tunnel; note that we can also use IP{v4,v6} addresses
 [[tunnels]]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -4,6 +4,11 @@
 # poll_interval = 10
 # stable_for = 30
 # cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
+#
+# [group.work]
+# vpn_required = true
+# auto_open_when_vpn = true
+# auto_close_when_vpn_lost = true
 
 # simple tunnel, uses local (-L) mode by default
 [[tunnels]]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,11 +11,14 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/alebeck/boring/internal/paths"
 	"github.com/alebeck/boring/internal/tunnel"
+	"github.com/alebeck/boring/internal/vpn"
 )
 
 const (
-	fileName   = ".boring.toml"
-	socksLabel = "[SOCKS]"
+	fileName               = ".boring.toml"
+	socksLabel             = "[SOCKS]"
+	defaultVPNPollInterval = 10 // seconds
+	defaultVPNStableFor    = 30 // seconds
 )
 
 var defaultKeepAliveInterval = 2 * 60 // seconds
@@ -28,8 +32,23 @@ type Config struct {
 	// KeepAlive allows to specify a global keep alive interval,
 	// (in seconds) overriding the default one. `0` indicates
 	// no keep alive.
-	KeepAlive  *int                    `toml:"keep_alive"`
+	KeepAlive *int `toml:"keep_alive"`
+	// VPN configures CIDR-based VPN detection for automatic tunnel reconciliation.
+	VPN        VPNConfig               `toml:"vpn"`
 	TunnelsMap map[string]*tunnel.Desc `toml:"-"`
+}
+
+// VPNConfig controls CIDR-based VPN detection in the daemon.
+type VPNConfig struct {
+	PollInterval int      `toml:"poll_interval"`
+	StableFor    int      `toml:"stable_for"`
+	CIDRs        []string `toml:"cidrs"`
+
+	ParsedCIDRs []*net.IPNet `toml:"-"`
+}
+
+func (c VPNConfig) Enabled() bool {
+	return len(c.ParsedCIDRs) > 0
 }
 
 func init() {
@@ -60,6 +79,10 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("could not decode config file: %w", err)
 	}
 
+	if err := normalizeVPNConfig(&cfg.VPN); err != nil {
+		return nil, err
+	}
+
 	// Set global keep alive interval for all tunnels
 	// that don't specify one on their own.
 	for i := range cfg.Tunnels {
@@ -88,6 +111,28 @@ func Load() (*Config, error) {
 
 	cfg.TunnelsMap = m
 	return &cfg, nil
+}
+
+func normalizeVPNConfig(cfg *VPNConfig) error {
+	if cfg.PollInterval < 0 {
+		return fmt.Errorf("vpn.poll_interval cannot be negative")
+	}
+	if cfg.StableFor < 0 {
+		return fmt.Errorf("vpn.stable_for cannot be negative")
+	}
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = defaultVPNPollInterval
+	}
+	if cfg.StableFor == 0 {
+		cfg.StableFor = defaultVPNStableFor
+	}
+
+	parsed, err := vpn.ParseCIDRs(cfg.CIDRs)
+	if err != nil {
+		return err
+	}
+	cfg.ParsedCIDRs = parsed
+	return nil
 }
 
 func buildTunnelsMap(tunnels []tunnel.Desc) (map[string]*tunnel.Desc, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,8 +34,17 @@ type Config struct {
 	// no keep alive.
 	KeepAlive *int `toml:"keep_alive"`
 	// VPN configures CIDR-based VPN detection for automatic tunnel reconciliation.
-	VPN        VPNConfig               `toml:"vpn"`
+	VPN VPNConfig `toml:"vpn"`
+	// Group allows default automation settings for tunnels in a group.
+	Group      map[string]GroupConfig  `toml:"group"`
 	TunnelsMap map[string]*tunnel.Desc `toml:"-"`
+}
+
+// GroupConfig controls defaults for tunnels assigned to a group.
+type GroupConfig struct {
+	VPNRequired          bool `toml:"vpn_required"`
+	AutoOpenWhenVPN      bool `toml:"auto_open_when_vpn"`
+	AutoCloseWhenVPNLost bool `toml:"auto_close_when_vpn_lost"`
 }
 
 // VPNConfig controls CIDR-based VPN detection in the daemon.
@@ -82,6 +91,9 @@ func Load() (*Config, error) {
 	if err := normalizeVPNConfig(&cfg.VPN); err != nil {
 		return nil, err
 	}
+	if err := validateGroupConfig(cfg.Group); err != nil {
+		return nil, err
+	}
 
 	// Set global keep alive interval for all tunnels
 	// that don't specify one on their own.
@@ -90,6 +102,7 @@ func Load() (*Config, error) {
 		if t.KeepAlive == nil {
 			t.KeepAlive = cfg.KeepAlive
 		}
+		applyGroupConfig(t, cfg.Group)
 	}
 
 	// Create a map of tunnel names to tunnel pointers for easy lookup later
@@ -111,6 +124,37 @@ func Load() (*Config, error) {
 
 	cfg.TunnelsMap = m
 	return &cfg, nil
+}
+
+func validateGroupConfig(groups map[string]GroupConfig) error {
+	for name := range groups {
+		if name == "" || strings.Contains(name, " ") ||
+			specialPrefix(name) || containsGlob(name) {
+			return fmt.Errorf("group names cannot be empty, contain spaces,"+
+				" start with special characters, or contain glob characters \"*?[\"."+
+				" Found '%v'", name)
+		}
+	}
+	return nil
+}
+
+func applyGroupConfig(t *tunnel.Desc, groups map[string]GroupConfig) {
+	if len(groups) == 0 {
+		return
+	}
+
+	group := t.Group
+	if group == "" {
+		group = "default"
+	}
+	cfg, ok := groups[group]
+	if !ok {
+		return
+	}
+
+	t.VPNRequired = t.VPNRequired || cfg.VPNRequired
+	t.AutoOpenWhenVPN = t.AutoOpenWhenVPN || cfg.AutoOpenWhenVPN
+	t.AutoCloseWhenVPNLost = t.AutoCloseWhenVPNLost || cfg.AutoCloseWhenVPNLost
 }
 
 func normalizeVPNConfig(cfg *VPNConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,98 @@ auto_close_when_vpn_lost = true
 	}
 }
 
+func TestLoadVPNGroupConfig(t *testing.T) {
+	oldPath := Path
+	t.Cleanup(func() { Path = oldPath })
+
+	Path = filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[group.work]
+vpn_required = true
+auto_open_when_vpn = true
+auto_close_when_vpn_lost = true
+
+[[tunnels]]
+name = "internal-api"
+group = "work"
+local = "9000"
+remote = "localhost:9000"
+host = "jumpbox"
+`
+	if err := os.WriteFile(Path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	desc := cfg.TunnelsMap["internal-api"]
+	if desc == nil {
+		t.Fatal("internal-api missing from TunnelsMap")
+	}
+	if !desc.VPNRequired || !desc.AutoOpenWhenVPN || !desc.AutoCloseWhenVPNLost {
+		t.Fatalf("VPN group flags were not applied: %+v", desc)
+	}
+}
+
+func TestLoadVPNDefaultGroupConfig(t *testing.T) {
+	oldPath := Path
+	t.Cleanup(func() { Path = oldPath })
+
+	Path = filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[group.default]
+vpn_required = true
+auto_open_when_vpn = true
+
+[[tunnels]]
+name = "internal-api"
+local = "9000"
+remote = "localhost:9000"
+host = "jumpbox"
+`
+	if err := os.WriteFile(Path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	desc := cfg.TunnelsMap["internal-api"]
+	if desc == nil {
+		t.Fatal("internal-api missing from TunnelsMap")
+	}
+	if !desc.VPNRequired || !desc.AutoOpenWhenVPN {
+		t.Fatalf("VPN default group flags were not applied: %+v", desc)
+	}
+}
+
+func TestLoadVPNInvalidGroupConfig(t *testing.T) {
+	oldPath := Path
+	t.Cleanup(func() { Path = oldPath })
+
+	Path = filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[group."bad group"]
+vpn_required = true
+`
+	if err := os.WriteFile(Path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "group names cannot") {
+		t.Fatalf("Load() error = %q, want invalid group", err)
+	}
+}
+
 func TestLoadVPNInvalidCIDR(t *testing.T) {
 	oldPath := Path
 	t.Cleanup(func() { Path = oldPath })

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadVPNConfig(t *testing.T) {
+	oldPath := Path
+	t.Cleanup(func() { Path = oldPath })
+
+	Path = filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[vpn]
+poll_interval = 5
+stable_for = 15
+cidrs = ["10.0.0.0/8"]
+
+[[tunnels]]
+name = "internal-api"
+local = "9000"
+remote = "localhost:9000"
+host = "jumpbox"
+vpn_required = true
+auto_open_when_vpn = true
+auto_close_when_vpn_lost = true
+`
+	if err := os.WriteFile(Path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.VPN.PollInterval != 5 {
+		t.Fatalf("VPN.PollInterval = %d, want 5", cfg.VPN.PollInterval)
+	}
+	if cfg.VPN.StableFor != 15 {
+		t.Fatalf("VPN.StableFor = %d, want 15", cfg.VPN.StableFor)
+	}
+	if !cfg.VPN.Enabled() {
+		t.Fatal("VPN.Enabled() = false, want true")
+	}
+	if len(cfg.VPN.ParsedCIDRs) != 1 {
+		t.Fatalf("len(VPN.ParsedCIDRs) = %d, want 1", len(cfg.VPN.ParsedCIDRs))
+	}
+
+	desc := cfg.TunnelsMap["internal-api"]
+	if desc == nil {
+		t.Fatal("internal-api missing from TunnelsMap")
+	}
+	if !desc.VPNRequired || !desc.AutoOpenWhenVPN || !desc.AutoCloseWhenVPNLost {
+		t.Fatalf("VPN tunnel flags were not parsed: %+v", desc)
+	}
+}
+
+func TestLoadVPNInvalidCIDR(t *testing.T) {
+	oldPath := Path
+	t.Cleanup(func() { Path = oldPath })
+
+	Path = filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[vpn]
+cidrs = ["not-a-cidr"]
+`
+	if err := os.WriteFile(Path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "invalid VPN CIDR") {
+		t.Fatalf("Load() error = %q, want invalid VPN CIDR", err)
+	}
+}
+
+func TestLoadVPNDefaults(t *testing.T) {
+	oldPath := Path
+	t.Cleanup(func() { Path = oldPath })
+
+	Path = filepath.Join(t.TempDir(), "config.toml")
+	content := `
+[vpn]
+cidrs = ["10.0.0.0/8"]
+`
+	if err := os.WriteFile(Path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.VPN.PollInterval != defaultVPNPollInterval {
+		t.Fatalf("VPN.PollInterval = %d, want %d", cfg.VPN.PollInterval, defaultVPNPollInterval)
+	}
+	if cfg.VPN.StableFor != defaultVPNStableFor {
+		t.Fatalf("VPN.StableFor = %d, want %d", cfg.VPN.StableFor, defaultVPNStableFor)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/alebeck/boring/internal/buildinfo"
+	"github.com/alebeck/boring/internal/config"
 	"github.com/alebeck/boring/internal/ipc"
 	"github.com/alebeck/boring/internal/log"
 	"github.com/alebeck/boring/internal/tunnel"
@@ -45,19 +46,29 @@ type daemon struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	ln     net.Listener
+	conf   *config.Config
 
 	// TODO: write proper concurrent map structure for this
 	tunnels map[string]*tunnel.Tunnel
+	opening map[string]bool
 	mutex   sync.RWMutex
 
 	once sync.Once
 	wg   sync.WaitGroup
 }
 
-func newDaemon(parent context.Context, ln net.Listener) (*daemon, context.CancelFunc) {
+func newDaemon(parent context.Context, ln net.Listener, conf *config.Config) (*daemon, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
 	tunnels := make(map[string]*tunnel.Tunnel)
-	d := &daemon{ctx: ctx, cancel: cancel, ln: ln, tunnels: tunnels}
+	opening := make(map[string]bool)
+	d := &daemon{
+		ctx:     ctx,
+		cancel:  cancel,
+		ln:      ln,
+		conf:    conf,
+		tunnels: tunnels,
+		opening: opening,
+	}
 
 	go func() {
 		// Parent-driven shutdown
@@ -151,26 +162,51 @@ func (d *daemon) openTunnel(conn net.Conn, desc *tunnel.Desc) {
 	var err error
 	defer func() { respond(conn, err, nil) }()
 
-	d.mutex.RLock()
-	_, exists := d.tunnels[desc.Name]
-	d.mutex.RUnlock()
-	if exists {
-		err = AlreadyRunning
+	if err = d.startTunnel(desc); err != nil {
 		log.Errorf("%v: could not open: %v", desc.Name, err)
-		return
+	}
+}
+
+func (d *daemon) startTunnel(desc *tunnel.Desc) error {
+	if err := d.reserveTunnel(desc.Name); err != nil {
+		return err
 	}
 
 	t := tunnel.FromDesc(desc)
-	if err = t.Open(); err != nil {
-		log.Errorf("%v: could not open: %v", t.Name, err)
-		return
+	if err := t.Open(); err != nil {
+		d.releaseOpening(desc.Name)
+		return err
 	}
 
 	d.mutex.Lock()
+	delete(d.opening, t.Name)
 	d.tunnels[t.Name] = t
 	d.mutex.Unlock()
 
-	// Register closing logic
+	d.registerTunnelCleanup(t)
+	return nil
+}
+
+func (d *daemon) reserveTunnel(name string) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	if _, exists := d.tunnels[name]; exists {
+		return AlreadyRunning
+	}
+	if d.opening[name] {
+		return AlreadyRunning
+	}
+	d.opening[name] = true
+	return nil
+}
+
+func (d *daemon) releaseOpening(name string) {
+	d.mutex.Lock()
+	delete(d.opening, name)
+	d.mutex.Unlock()
+}
+
+func (d *daemon) registerTunnelCleanup(t *tunnel.Tunnel) {
 	go func() {
 		<-t.Closed
 		d.mutex.Lock()
@@ -184,20 +220,27 @@ func (d *daemon) closeTunnel(conn net.Conn, q *tunnel.Desc) {
 	var err error
 	defer func() { respond(conn, err, nil) }()
 
-	d.mutex.RLock()
-	t, ok := d.tunnels[q.Name]
-	d.mutex.RUnlock()
-	if !ok {
-		err = fmt.Errorf("tunnel not running")
+	if err = d.stopTunnel(q.Name); err != nil {
 		log.Errorf("%v: could not close tunnel: %v", q.Name, err)
-		return
+	}
+}
+
+func (d *daemon) stopTunnel(name string) error {
+	d.mutex.Lock()
+	t, ok := d.tunnels[name]
+	if ok {
+		delete(d.tunnels, name)
+	}
+	d.mutex.Unlock()
+	if !ok {
+		return fmt.Errorf("tunnel not running")
 	}
 
-	if err = t.Close(); err != nil {
-		log.Errorf("%v: could not close tunnel: %v", t.Name, err)
-		return
+	if err := t.Close(); err != nil {
+		return err
 	}
 	<-t.Closed
+	return nil
 }
 
 func (d *daemon) listTunnels(conn net.Conn) {
@@ -274,11 +317,17 @@ func Run() {
 	}
 	log.Infof("Listening on %s", ln.Addr())
 
+	conf, err := config.Load()
+	if err != nil {
+		log.Warningf("Could not load config for VPN automation; disabling: %v", err)
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	d, cleanup := newDaemon(ctx, ln)
+	d, cleanup := newDaemon(ctx, ln, conf)
 	defer cleanup()
+	d.startVPNReconciler()
 
 	d.serve()
 }

--- a/internal/daemon/vpn_reconcile.go
+++ b/internal/daemon/vpn_reconcile.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"errors"
+	"time"
+
+	"github.com/alebeck/boring/internal/log"
+	"github.com/alebeck/boring/internal/tunnel"
+	"github.com/alebeck/boring/internal/vpn"
+)
+
+type vpnActionPlan struct {
+	open  []*tunnel.Desc
+	close []string
+}
+
+func (d *daemon) startVPNReconciler() {
+	if d.conf == nil || !d.conf.VPN.Enabled() || !hasVPNAutomation(d.conf.Tunnels) {
+		return
+	}
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		d.runVPNReconciler()
+	}()
+}
+
+func hasVPNAutomation(tunnels []tunnel.Desc) bool {
+	for _, desc := range tunnels {
+		if desc.AutoOpenWhenVPN || desc.AutoCloseWhenVPNLost {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *daemon) runVPNReconciler() {
+	pollInterval := time.Duration(d.conf.VPN.PollInterval) * time.Second
+	stableFor := time.Duration(d.conf.VPN.StableFor) * time.Second
+	state := vpn.NewStableState(stableFor)
+
+	log.Infof(
+		"Starting VPN reconciler with poll interval %s and stable window %s",
+		pollInterval,
+		stableFor,
+	)
+
+	d.observeAndReconcileVPN(state, time.Now())
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case now := <-ticker.C:
+			d.observeAndReconcileVPN(state, now)
+		}
+	}
+}
+
+func (d *daemon) observeAndReconcileVPN(state *vpn.StableState, now time.Time) {
+	onVPN, err := vpn.OnVPN(d.conf.VPN.ParsedCIDRs)
+	if err != nil {
+		log.Errorf("Could not check VPN state: %v", err)
+		return
+	}
+
+	stable, changed, ok := state.Observe(onVPN, now)
+	if !ok {
+		log.Debugf("Observed VPN state %v; waiting for stable window", onVPN)
+		return
+	}
+	if changed {
+		log.Infof("VPN state is now %v", stable)
+	}
+	d.reconcileVPNState(stable)
+}
+
+func (d *daemon) reconcileVPNState(onVPN bool) {
+	d.mutex.RLock()
+	running := make(map[string]bool, len(d.tunnels))
+	for name := range d.tunnels {
+		running[name] = true
+	}
+	opening := make(map[string]bool, len(d.opening))
+	for name := range d.opening {
+		opening[name] = true
+	}
+	d.mutex.RUnlock()
+
+	plan := planVPNActions(d.conf.Tunnels, running, opening, onVPN)
+
+	for _, desc := range plan.open {
+		if err := d.startTunnel(desc); err != nil && !errors.Is(err, AlreadyRunning) {
+			log.Errorf("%v: could not auto-open for VPN state: %v", desc.Name, err)
+		}
+	}
+
+	for _, name := range plan.close {
+		if err := d.stopTunnel(name); err != nil {
+			log.Errorf("%v: could not auto-close for VPN state: %v", name, err)
+		}
+	}
+}
+
+func planVPNActions(
+	tunnels []tunnel.Desc,
+	running map[string]bool,
+	opening map[string]bool,
+	onVPN bool,
+) vpnActionPlan {
+	var plan vpnActionPlan
+
+	for i := range tunnels {
+		desc := &tunnels[i]
+		eligible := !desc.VPNRequired || onVPN
+		isRunning := running[desc.Name]
+		isOpening := opening[desc.Name]
+
+		if eligible && desc.AutoOpenWhenVPN && !isRunning && !isOpening {
+			plan.open = append(plan.open, desc)
+		}
+		if !eligible && desc.AutoCloseWhenVPNLost && isRunning {
+			plan.close = append(plan.close, desc.Name)
+		}
+	}
+
+	return plan
+}

--- a/internal/daemon/vpn_reconcile_test.go
+++ b/internal/daemon/vpn_reconcile_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/alebeck/boring/internal/tunnel"
+)
+
+var vpnPlanTestTunnels = []tunnel.Desc{
+	{
+		Name:                 "work-api",
+		VPNRequired:          true,
+		AutoOpenWhenVPN:      true,
+		AutoCloseWhenVPNLost: true,
+	},
+	{
+		Name:                 "manual-close",
+		VPNRequired:          true,
+		AutoCloseWhenVPNLost: true,
+	},
+	{
+		Name:            "manual-keep",
+		VPNRequired:     true,
+		AutoOpenWhenVPN: true,
+	},
+	{
+		Name:            "always-on",
+		AutoOpenWhenVPN: true,
+	},
+}
+
+func TestPlanVPNActionsOpen(t *testing.T) {
+	plan := planVPNActions(
+		vpnPlanTestTunnels,
+		map[string]bool{},
+		map[string]bool{},
+		true,
+	)
+	assertVPNPlan(t, plan,
+		[]string{"work-api", "manual-keep", "always-on"},
+		nil,
+	)
+}
+
+func TestPlanVPNActionsNoDuplicateOpen(t *testing.T) {
+	plan := planVPNActions(
+		vpnPlanTestTunnels,
+		map[string]bool{"work-api": true},
+		map[string]bool{"manual-keep": true},
+		true,
+	)
+	assertVPNPlan(t, plan, []string{"always-on"}, nil)
+}
+
+func TestPlanVPNActionsClose(t *testing.T) {
+	plan := planVPNActions(
+		vpnPlanTestTunnels,
+		map[string]bool{
+			"work-api":     true,
+			"manual-close": true,
+			"manual-keep":  true,
+			"always-on":    true,
+		},
+		map[string]bool{},
+		false,
+	)
+	assertVPNPlan(t, plan, nil, []string{"work-api", "manual-close"})
+}
+
+func TestPlanVPNActionsOpenWithoutVPNRequired(t *testing.T) {
+	plan := planVPNActions(
+		vpnPlanTestTunnels,
+		map[string]bool{},
+		map[string]bool{},
+		false,
+	)
+	assertVPNPlan(t, plan, []string{"always-on"}, nil)
+}
+
+func assertVPNPlan(t *testing.T, plan vpnActionPlan, wantOpen, wantClose []string) {
+	gotOpen := tunnelNames(plan.open)
+	if !reflect.DeepEqual(gotOpen, wantOpen) {
+		t.Fatalf("open = %v, want %v", gotOpen, wantOpen)
+	}
+	if !reflect.DeepEqual(plan.close, wantClose) {
+		t.Fatalf("close = %v, want %v", plan.close, wantClose)
+	}
+}
+
+func tunnelNames(tunnels []*tunnel.Desc) []string {
+	var names []string
+	for _, desc := range tunnels {
+		names = append(names, desc.Name)
+	}
+	return names
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -25,18 +25,21 @@ const (
 // Desc describes a tunnel for user-facing purposes, e.g., in the config file
 // and in the TUI.
 type Desc struct {
-	Name          string      `toml:"name" json:"name"`
-	LocalAddress  StringOrInt `toml:"local" json:"local"`
-	RemoteAddress StringOrInt `toml:"remote" json:"remote"`
-	Host          string      `toml:"host" json:"host"`
-	User          string      `toml:"user" json:"user"`
-	IdentityFile  string      `toml:"identity" json:"identity"`
-	Port          int         `toml:"port" json:"port"`
-	KeepAlive     *int        `toml:"keep_alive" json:"keep_alive"`
-	Group         string      `toml:"group" json:"group"`
-	Mode          Mode        `toml:"mode" json:"mode"`
-	Status        Status      `toml:"-" json:"status"`
-	LastConn      time.Time   `toml:"-" json:"last_conn"`
+	Name                 string      `toml:"name" json:"name"`
+	LocalAddress         StringOrInt `toml:"local" json:"local"`
+	RemoteAddress        StringOrInt `toml:"remote" json:"remote"`
+	Host                 string      `toml:"host" json:"host"`
+	User                 string      `toml:"user" json:"user"`
+	IdentityFile         string      `toml:"identity" json:"identity"`
+	Port                 int         `toml:"port" json:"port"`
+	KeepAlive            *int        `toml:"keep_alive" json:"keep_alive"`
+	Group                string      `toml:"group" json:"group"`
+	VPNRequired          bool        `toml:"vpn_required" json:"vpn_required"`
+	AutoOpenWhenVPN      bool        `toml:"auto_open_when_vpn" json:"auto_open_when_vpn"`
+	AutoCloseWhenVPNLost bool        `toml:"auto_close_when_vpn_lost" json:"auto_close_when_vpn_lost"`
+	Mode                 Mode        `toml:"mode" json:"mode"`
+	Status               Status      `toml:"-" json:"status"`
+	LastConn             time.Time   `toml:"-" json:"last_conn"`
 }
 
 // Tunnel is a representation internal to the tunnel and daemon packages,

--- a/internal/vpn/cidr.go
+++ b/internal/vpn/cidr.go
@@ -1,0 +1,86 @@
+package vpn
+
+import (
+	"fmt"
+	"net"
+)
+
+// ParseCIDRs parses CIDR strings used to detect whether the machine is on VPN.
+func ParseCIDRs(cidrs []string) ([]*net.IPNet, error) {
+	parsed := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid VPN CIDR '%v': %w", cidr, err)
+		}
+		parsed = append(parsed, ipNet)
+	}
+	return parsed, nil
+}
+
+func interfaceIPs() ([]net.IP, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []net.IP
+	for _, iface := range interfaces {
+		isUp := iface.Flags&net.FlagUp != 0
+		isLoopback := iface.Flags&net.FlagLoopback != 0
+		if !isUp || isLoopback {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, fmt.Errorf("could not read addresses for interface '%v': %w", iface.Name, err)
+		}
+		for _, addr := range addrs {
+			ip := ipFromAddr(addr)
+			if ip == nil {
+				continue
+			}
+			ips = append(ips, normalizeIP(ip))
+		}
+	}
+	return ips, nil
+}
+
+// OnVPN reports whether any active local interface address is inside any CIDR.
+func OnVPN(cidrs []*net.IPNet) (bool, error) {
+	ips, err := interfaceIPs()
+	if err != nil {
+		return false, err
+	}
+	return anyIPInCIDRs(ips, cidrs), nil
+}
+
+func anyIPInCIDRs(ips []net.IP, cidrs []*net.IPNet) bool {
+	for _, ip := range ips {
+		for _, cidr := range cidrs {
+			if cidr.Contains(normalizeIP(ip)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ipFromAddr(addr net.Addr) net.IP {
+	switch a := addr.(type) {
+	case *net.IPNet:
+		return a.IP
+	case *net.IPAddr:
+		return a.IP
+	default:
+		return nil
+	}
+}
+
+func normalizeIP(ip net.IP) net.IP {
+	if v4 := ip.To4(); v4 != nil {
+		return v4
+	}
+	return ip
+}

--- a/internal/vpn/cidr_test.go
+++ b/internal/vpn/cidr_test.go
@@ -1,0 +1,57 @@
+package vpn
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIPInsideCIDR(t *testing.T) {
+	cidrs, err := ParseCIDRs([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ips := []net.IP{net.ParseIP("10.20.30.40")}
+	if !anyIPInCIDRs(ips, cidrs) {
+		t.Fatalf("IP did not match CIDR")
+	}
+}
+
+func TestIPOutsideCIDR(t *testing.T) {
+	cidrs, err := ParseCIDRs([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ips := []net.IP{net.ParseIP("192.168.1.10")}
+	if anyIPInCIDRs(ips, cidrs) {
+		t.Fatalf("IP matched CIDR")
+	}
+}
+
+func TestMultipleCIDRs(t *testing.T) {
+	cidrs, err := ParseCIDRs([]string{"10.0.0.0/8", "172.16.0.0/12"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ips := []net.IP{net.ParseIP("172.16.1.10")}
+	if !anyIPInCIDRs(ips, cidrs) {
+		t.Fatalf("IP did not match any CIDR")
+	}
+}
+
+func TestMultipleIPs(t *testing.T) {
+	cidrs, err := ParseCIDRs([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ips := []net.IP{net.ParseIP("192.168.1.10"), net.ParseIP("10.1.2.3")}
+	if !anyIPInCIDRs(ips, cidrs) {
+		t.Fatalf("no IP matched CIDR")
+	}
+}
+
+func TestParseCIDRsInvalid(t *testing.T) {
+	_, err := ParseCIDRs([]string{"not-a-cidr"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/vpn/stable_state.go
+++ b/internal/vpn/stable_state.go
@@ -1,0 +1,42 @@
+package vpn
+
+import "time"
+
+// StableState debounces observed boolean state changes until the same value has
+// been observed for a configured duration.
+type StableState struct {
+	stableFor time.Duration
+
+	observed      bool
+	observedSet   bool
+	observedSince time.Time
+
+	stable    bool
+	stableSet bool
+}
+
+// NewStableState returns a state debouncer. A zero stableFor duration makes
+// observations stable immediately.
+func NewStableState(stableFor time.Duration) *StableState {
+	return &StableState{stableFor: stableFor}
+}
+
+// Observe records an observed state at now. The returned ok value is true once
+// the observed value has been stable long enough. When ok is true, stable is the
+// debounced state. The changed value reports whether the debounced state changed.
+func (s *StableState) Observe(value bool, now time.Time) (stable bool, changed bool, ok bool) {
+	if !s.observedSet || s.observed != value {
+		s.observed = value
+		s.observedSet = true
+		s.observedSince = now
+	}
+
+	if s.stableFor > 0 && now.Sub(s.observedSince) < s.stableFor {
+		return false, false, false
+	}
+
+	changed = !s.stableSet || s.stable != s.observed
+	s.stable = s.observed
+	s.stableSet = true
+	return s.stable, changed, true
+}

--- a/internal/vpn/stable_state_test.go
+++ b/internal/vpn/stable_state_test.go
@@ -1,0 +1,54 @@
+package vpn
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStableState(t *testing.T) {
+	start := time.Unix(100, 0)
+	state := NewStableState(30 * time.Second)
+
+	if _, _, ok := state.Observe(true, start); ok {
+		t.Fatal("Observe() ok = true on first observation, want false")
+	}
+
+	if _, _, ok := state.Observe(true, start.Add(29*time.Second)); ok {
+		t.Fatal("Observe() ok = true before stable window, want false")
+	}
+
+	stable, changed, ok := state.Observe(true, start.Add(30*time.Second))
+	if !ok || !stable || !changed {
+		t.Fatalf("Observe() = (%v, %v, %v), want (true, true, true)", stable, changed, ok)
+	}
+
+	stable, changed, ok = state.Observe(true, start.Add(31*time.Second))
+	if !ok || !stable || changed {
+		t.Fatalf("Observe() = (%v, %v, %v), want (true, false, true)", stable, changed, ok)
+	}
+}
+
+func TestStableStateChangeResetsWindow(t *testing.T) {
+	start := time.Unix(100, 0)
+	state := NewStableState(30 * time.Second)
+
+	state.Observe(true, start)
+	state.Observe(true, start.Add(30*time.Second))
+
+	if _, _, ok := state.Observe(false, start.Add(31*time.Second)); ok {
+		t.Fatal("Observe() ok = true immediately after state change, want false")
+	}
+
+	stable, changed, ok := state.Observe(false, start.Add(61*time.Second))
+	if !ok || stable || !changed {
+		t.Fatalf("Observe() = (%v, %v, %v), want (false, true, true)", stable, changed, ok)
+	}
+}
+
+func TestStableStateZeroDuration(t *testing.T) {
+	state := NewStableState(0)
+	stable, changed, ok := state.Observe(true, time.Unix(100, 0))
+	if !ok || !stable || !changed {
+		t.Fatalf("Observe() = (%v, %v, %v), want (true, true, true)", stable, changed, ok)
+	}
+}


### PR DESCRIPTION
_This PR was generated with AI assistance._ I understand if you do not want to merge it.

 It adds VPN-aware auto-open/auto-close support for selected boring tunnels. The daemon can now poll local network interfaces, detect whether the machine appears to be on VPN by matching interface IPs against
 configured CIDR ranges, debounce state changes, and reconcile selected tunnels automatically.

 Changes

 - Added top-level VPN config support:

 ```toml
   [vpn]
   poll_interval = 10
   stable_for = 30
   cidrs = ["10.0.0.0/8", "172.16.0.0/12"]
 ```

 - Added tunnel-level VPN automation flags:

 ```toml
   vpn_required = true
   auto_open_when_vpn = true
   auto_close_when_vpn_lost = true
 ```

 - Added CIDR-based VPN detection from active, non-loopback interfaces.
 - Added stable-state debounce logic to avoid flapping during short network transitions.
 - Added a daemon reconciliation loop that:
     - auto-opens eligible tunnels when VPN is detected
     - optionally closes marked tunnels when VPN is lost
     - avoids duplicate opens
     - reuses the existing tunnel lifecycle code
 - Added unit tests for:
     - CIDR matching/parsing
     - debounce behavior
     - config parsing
     - VPN reconcile planning
 - Updated README, example config, and generated default config comments.
 - Added group-level VPN automation defaults.


Tunnels can still set VPN automation flags directly, but shared defaults can now be defined once per group:

```toml
[group.work]
vpn_required = true
auto_open_when_vpn = true
auto_close_when_vpn_lost = true

[[tunnels]]
name = "internal-api"
group = "work"
```

 Ungrouped tunnels can use [group.default].

 I also added validation for group default table names so they follow the same naming rules as existing tunnel groups.

 Why

 The motivating use case is a work laptop where certain tunnels should only come up when connected to the company VPN. Instead of manually running something like:

 ```sh
   boring open -g work
 ```

 after each VPN connection, users can now mark work tunnels for VPN automation and let the daemon open/close them based on VPN network state.

 Validation

 Ran:

 ```sh
   go test ./cmd/... ./internal/...
   go test -race ./cmd/... ./internal/...
   go vet ./cmd/... ./internal/...
   git diff --check
 ```